### PR TITLE
Orthographe : fabriquant -> fabricant

### DIFF
--- a/myteaparty/templates/base.html
+++ b/myteaparty/templates/base.html
@@ -89,7 +89,7 @@
                                 Origines
                             </a>
                             <a href="{{ url_for('by_vendor') }}" class="navbar-item">
-                                Fabriquants
+                                Fabricants
                             </a>
                         {% endblock %}
                     </div>


### PR DESCRIPTION
Parce que c'est pas le verbe mais le nom